### PR TITLE
Updated Fira Code Nerd Font URL

### DIFF
--- a/Fira Code Nerd Font.css
+++ b/Fira Code Nerd Font.css
@@ -2,21 +2,21 @@
     font-family: "Fira Code Nerd Font";
     font-style: normal;
     font-weight: 200;
-    src: url('https://github.com/ryanoasis/nerd-fonts/raw/master/patched-fonts/FiraCode/Light/complete/Fura%20Code%20Light%20Nerd%20Font%20Complete.ttf') format('truetype');
+    src: url('https://github.com/ryanoasis/nerd-fonts/raw/master/patched-fonts/FiraCode/Light/complete/Fira%20Code%20Light%20Nerd%20Font%20Complete.ttf') format('truetype');
 }
 @font-face {
     font-family: "Fira Code Nerd Font";
     font-style: normal;
     font-weight: 400;
-    src: url('https://github.com/ryanoasis/nerd-fonts/raw/master/patched-fonts/FiraCode/Retina/complete/Fura%20Code%20Retina%20Nerd%20Font%20Complete.ttf') format('truetype');
+    src: url('https://github.com/ryanoasis/nerd-fonts/raw/master/patched-fonts/FiraCode/Retina/complete/Fira%20Code%20Retina%20Nerd%20Font%20Complete.ttf') format('truetype');
 }
 @font-face {
     font-family: "Fira Code Nerd Font";
     font-weight: 600;
-    src: url('https://github.com/ryanoasis/nerd-fonts/raw/master/patched-fonts/FiraCode/Medium/complete/Fura%20Code%20Medium%20Nerd%20Font%20Complete.ttf') format('truetype');
+    src: url('https://github.com/ryanoasis/nerd-fonts/raw/master/patched-fonts/FiraCode/Medium/complete/Fira%20Code%20Medium%20Nerd%20Font%20Complete.ttf') format('truetype');
 }
 @font-face {
     font-family: "Fira Code Nerd Font";
     font-weight: 800;
-    src: url('https://github.com/ryanoasis/nerd-fonts/raw/master/patched-fonts/FiraCode/Bold/complete/Fura%20Code%20Bold%20Nerd%20Font%20Complete.ttf') format('truetype');
+    src: url('https://github.com/ryanoasis/nerd-fonts/raw/master/patched-fonts/FiraCode/Bold/complete/Fira%20Code%20Bold%20Nerd%20Font%20Complete.ttf') format('truetype');
 }


### PR DESCRIPTION
The files are called `Fira` now and not `Fura` anymore.