### PR TITLE
Update JetBrains Mono Nerd Font.css

### DIFF
--- a/JetBrains Mono Nerd Font.css
+++ b/JetBrains Mono Nerd Font.css
@@ -2,47 +2,47 @@
     font-family: "JetBrains Mono Nerd Font";
     font-style: normal;
     font-weight: 200;
-    src: url('https://github.com/ryanoasis/nerd-fonts/raw/master/patched-fonts/JetBrainsMono/Ligatures/ExtraLight/complete/JetBrains%20Mono%20ExtraLight%20Nerd%20Font%20Complete.ttf') format('truetype');
+    src: url('https://github.com/ryanoasis/nerd-fonts/raw/master/patched-fonts/JetBrainsMono/Ligatures/ExtraLight/complete/JetBrains%20Mono%20ExtraLight%20Nerd%20Font%20Complete%20Mono.ttf') format('truetype');
 }
 @font-face {
     font-family: "JetBrains Mono Nerd Font";
     font-style: normal;
     font-weight: 400;
-    src: url('https://github.com/ryanoasis/nerd-fonts/raw/master/patched-fonts/JetBrainsMono/Ligatures/Regular/complete/JetBrains%20Mono%20Regular%20Nerd%20Font%20Complete.ttf') format('truetype');
+    src: url('https://github.com/ryanoasis/nerd-fonts/raw/master/patched-fonts/JetBrainsMono/Ligatures/Regular/complete/JetBrains%20Mono%20Regular%20Nerd%20Font%20Complete%20Mono.ttf') format('truetype');
 }
 @font-face {
     font-family: "JetBrains Mono Nerd Font";
     font-style: normal;
     font-weight: 500;
-    src: url('https://github.com/ryanoasis/nerd-fonts/raw/master/patched-fonts/JetBrainsMono/Ligatures/Medium/complete/JetBrains%20Mono%20Medium%20Nerd%20Font%20Complete.ttf') format('truetype');
+    src: url('https://github.com/ryanoasis/nerd-fonts/raw/master/patched-fonts/JetBrainsMono/Ligatures/Medium/complete/JetBrains%20Mono%20Medium%20Nerd%20Font%20Complete%20Mono.ttf') format('truetype');
 }
 @font-face {
     font-family: "JetBrains Mono Nerd Font";
     font-style: normal;
     font-weight: 700;
-    src: url('https://github.com/ryanoasis/nerd-fonts/raw/master/patched-fonts/JetBrainsMono/Ligatures/Bold/complete/JetBrains%20Mono%20Bold%20Nerd%20Font%20Complete.ttf') format('truetype');
+    src: url('https://github.com/ryanoasis/nerd-fonts/raw/master/patched-fonts/JetBrainsMono/Ligatures/Bold/complete/JetBrains%20Mono%20Bold%20Nerd%20Font%20Complete%20Mono.ttf') format('truetype');
 }
 @font-face {
     font-family: "JetBrains Mono Nerd Font";
     font-style: italic;
     font-weight: 200;
-    src: url('https://github.com/ryanoasis/nerd-fonts/raw/master/patched-fonts/JetBrainsMono/Ligatures/ExtraLightItalic/complete/JetBrains%20Mono%20ExtraLight%20Italic%20Nerd%20Font%20Complete.ttf') format('truetype');
+    src: url('https://github.com/ryanoasis/nerd-fonts/raw/master/patched-fonts/JetBrainsMono/Ligatures/ExtraLightItalic/complete/JetBrains%20Mono%20ExtraLight%20Italic%20Nerd%20Font%20Complete%20Mono.ttf') format('truetype');
 }
 @font-face {
     font-family: "JetBrains Mono Nerd Font";
     font-style: italic;
     font-weight: 400;
-    src: url('https://github.com/ryanoasis/nerd-fonts/raw/master/patched-fonts/JetBrainsMono/Ligatures/Italic/complete/JetBrains%20Mono%20Italic%20Nerd%20Font%20Complete.ttf') format('truetype');
+    src: url('https://github.com/ryanoasis/nerd-fonts/raw/master/patched-fonts/JetBrainsMono/Ligatures/Italic/complete/JetBrains%20Mono%20Italic%20Nerd%20Font%20Complete%20Mono.ttf') format('truetype');
 }
 @font-face {
     font-family: "JetBrains Mono Nerd Font";
     font-style: italic;
     font-weight: 500;
-    src: url('https://github.com/ryanoasis/nerd-fonts/raw/master/patched-fonts/JetBrainsMono/Ligatures/MediumItalic/complete/JetBrains%20Mono%20Medium%20Italic%20Nerd%20Font%20Complete.ttf') format('truetype');
+    src: url('https://github.com/ryanoasis/nerd-fonts/raw/master/patched-fonts/JetBrainsMono/Ligatures/MediumItalic/complete/JetBrains%20Mono%20Medium%20Italic%20Nerd%20Font%20Complete%20Mono.ttf') format('truetype');
 }
 @font-face {
     font-family: "JetBrains Mono Nerd Font";
     font-style: italic;
     font-weight: 700;
-    src: url('https://github.com/ryanoasis/nerd-fonts/raw/master/patched-fonts/JetBrainsMono/Ligatures/BoldItalic/complete/JetBrains%20Mono%20Bold%20Italic%20Nerd%20Font%20Complete.ttf') format('truetype');
+    src: url('https://github.com/ryanoasis/nerd-fonts/raw/master/patched-fonts/JetBrainsMono/Ligatures/BoldItalic/complete/JetBrains%20Mono%20Bold%20Italic%20Nerd%20Font%20Complete%20Mono.ttf') format('truetype');
 }


### PR DESCRIPTION
* Fix font width problem by using the latest version.
* Add more font weights so we have:
    * 200: ExtraLight/ExtraLightItalic
    * 400: Regular/Italic
    * 500: Medium/MediumItalic
    * 700: Bold/BoldItalic
* Change JetBrains Mono Nerd Font to monospaced (Nerd Font glyphs are monospaced). This gives better display because Blink Shell seems to support monospace font only.